### PR TITLE
Handle charset=utf-8

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,8 +6,9 @@ function fileStr(filePath) {
 }
 
 function decodeInlineSourceMap(inlineSourceMap){
-  if (/^;base64,/.test(inlineSourceMap)) {
-    var buffer = new Buffer(inlineSourceMap.slice(';base64,'.length), 'base64');
+  var encoding = /^(?:;charset=utf-8)?;base64,/;
+  if (encoding.test(inlineSourceMap)) {
+    var buffer = new Buffer(inlineSourceMap.slice(inlineSourceMap.match(encoding)[0].length), 'base64');
     return buffer.toString();
   } else {
     return decodeURIComponent(inlineSourceMap);


### PR DESCRIPTION
Handle case where charset=utf-8 is defined (as used in the likes of `inline-source-map` -> `combine-source-map` -> `browserify`)